### PR TITLE
Add tmux,screen,htop,ncdu,man-db and tree to minimal packages.

### DIFF
--- a/configs/core/packages.yaml
+++ b/configs/core/packages.yaml
@@ -43,13 +43,16 @@ variants:
       - fake-hwclock
       - gdisk
       - gpiod
+      - htop
       - i2c-tools
       - ifupdown
       - initramfs-tools
       - lsof
+      - man-db
       - mmc-utils
       - mtd-utils
       - nano
+      - ncdu
       - netcat-openbsd
       - net-tools
       - network-manager
@@ -59,10 +62,13 @@ variants:
       - psmisc
       - resolvconf
       - rsync
+      - screen
       - ssh
       - sudo
       - sysfsutils
       - sysstat
+      - tmux
+      - tree
       - ucf
       - usbutils
       - wget


### PR DESCRIPTION
These are all very useful packages to have in a server installation. My estimate is that these fit within 10-30 MB so the image does not get significantly bigger.

### tmux/screen
These are terminal multiplexers. These are essential on any server installation. Any proces that is started from a shell becomes a child process of that shell. If the shell is started via ssh and the connection is lost, that means that all the processes started from that shell are killed. This makes it very dangerous to perform system updates or other long-running processes that alter the system over ssh. 

A terminal multiplexer solves this problem by starting a separate shell on the host as a server process. As long as the system does not shut down this shell will continue existing. With the terminal multiplexer you "attach" to this shell. When the ssh connection is lost, only the attachment is lost, not the shell. After reconnecting with ssh, the session can be attached to again.
Also this allows starting a long-running process, detaching, close the ssh connection. The process can be checked upon later when reconnecting and will continue to run. Therefore a terminal multiplexer is essential on any server.

Another advantage of a terminal multiplexer is that it allows you to view multiple terminal windows side by side inside a single terminal window. Very useful!

Screen is a terminal multiplexer from the 80's, tmux is from 2008. Tmux is objectively better, but it also comes down to habits (compare nano/vim which are also both on the image). Since both have virtually the same dependencies adding them both does not add much weight on the image. 

### htop

Like top, but a colourful well-designed ncurses interface that also show cpu usage bars. Checking system load and what is causing the most load is much easier and quicker at a glance using htop. 

### ncdu
This is an interactive ncurses version of du. It sorts directories and files by size and you can interactively delete them. It is extremely useful for freeing up disk space and it only uses 100kb itself. A must have!

### man-db
Manpages. Very useful! The manpages are installed on the system already, but simply not viewable yet, since the man command is missing. This adds the man command and creates the man-db. I do not know how this affects the size, but I'd argue that being able to look up tool information on the command line is worth the expense. For example the find command is so complex that I always need the man page for more advanced use cases.

### Tree
Very small application that shows the directory layout and all subdirectory layouts as a tree. Very useful.
