### PR TITLE
Fix SetupTimezone by removing file `/etc/localtime` before running `dpkg-reconfigure tzdata`

### DIFF
--- a/olimage/core/setup/timezone.py
+++ b/olimage/core/setup/timezone.py
@@ -12,5 +12,7 @@ class SetupTimezone(SetupAbstract):
         Utils.install(file)
         Utils.template.install(env.paths['build'] + file, timezone=timezone)
 
+        Utils.shell.chroot('rm -f /etc/localtime')
+
         # Reconfigure
         Utils.shell.chroot('dpkg-reconfigure -f noninteractive tzdata')


### PR DESCRIPTION
I found that the `olimage` flag `--timezone` option does not work because it populates the file `/etc/timezone` with the value given in the option, but it doesn't remove `/etc/localtime` before it runs  `dpkg-reconfigure -f noninteractive tzdata`.

For example running `olimage image --timezone Australia/Melbourne ...`:
```
I: Configuring timezone: 'Australia/Melbourne'
Installing /olimage/overlay/etc/timezone to /olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone with permissions 644
run external command: [['install', '-D', '-v', '-m', '644', '/olimage/overlay/etc/timezone', '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone']]
removed '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone'
'/olimage/overlay/etc/timezone' -> '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone'
Installing template files: /olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone
Generating template file : /olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone
run external command: [['chroot', '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal', 'dpkg-reconfigure', '-f', 'noninteractive', 'tzdata']]

Current default time zone: 'Etc/UTC'
Local time is now:      Tue May 31 02:26:19 UTC 2022.
Universal Time is now:  Tue May 31 02:26:19 UTC 2022.
```

It just gets reset to UTC.

With the change in this PR:
```
I: Configuring timezone: 'Australia/Melbourne'
Installing /olimage/overlay/etc/timezone to /olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone with permissions 644
run external command: [['install', '-D', '-v', '-m', '644', '/olimage/overlay/etc/timezone', '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone']]
removed '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone'
'/olimage/overlay/etc/timezone' -> '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone'
Installing template files: /olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone
Generating template file : /olimage/output/a20-olinuxino/filesystem/bullseye-minimal/etc/timezone
run external command: [['chroot', '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal', 'rm', '-f', '/etc/localtime']]
run external command: [['chroot', '/olimage/output/a20-olinuxino/filesystem/bullseye-minimal', 'dpkg-reconfigure', '-f', 'noninteractive', 'tzdata']]

Current default time zone: 'Australia/Melbourne'
Local time is now:      Tue May 31 13:15:55 AEST 2022.
Universal Time is now:  Tue May 31 03:15:55 UTC 2022.
```

It works!

The solution in the PR retains the use of the `/etc/timezone` template.  However, an alternative would be to run the command `timedatectl set-timezone Australia/Melbourne`, so we could replace the entire `setup` function with simply:
```
    def setup(self, timezone: str):
        Utils.shell.chroot('timedatectl set-timezone {timezone}')
```