### PR TITLE
Add extra-file extra-cmd extra-package options

### DIFF
--- a/olimage/core/setup/extra.py
+++ b/olimage/core/setup/extra.py
@@ -17,3 +17,10 @@ class SetupExtra(SetupAbstract):
         Utils.shell.run('sed -i "s/^#SystemMaxUse=.*/SystemMaxUse=64M/g" {}/etc/systemd/journald.conf'.format(env.paths['build']))
         Utils.shell.run('sed -i "s/^#RuntimeMaxFileSize=.*/RuntimeMaxFileSize=8M/g" {}/etc/systemd/journald.conf'.format(env.paths['build']))
         Utils.shell.run('sed -i "s/^#RuntimeMaxUse=.*/RuntimeMaxUse=16M/g" {}/etc/systemd/journald.conf'.format(env.paths['build']))
+
+        for file in env.options['extra_file']:
+            with Console(f'Extra file: {file}'):
+                Utils.install(file)
+        for cmd in env.options['extra_cmd']:
+            with Console(f'Extra command: {cmd}'):
+                Utils.shell.chroot(cmd)

--- a/olimage/filesystem/__init__.py
+++ b/olimage/filesystem/__init__.py
@@ -35,6 +35,12 @@ def verify_options():
 
     env.options['release'] = release
 
+    # Verify any extra files exist in overlays
+    overlay_dir = env.paths['overlay']
+    for file in env.options['extra_file']:
+        if not os.path.isfile(f'{overlay_dir}/{file}'):
+            raise Exception(f"Extra file '{file}' not found in overlays")
+
 
 @click.command(name="filesystem")
 @parameters

--- a/olimage/filesystem/base.py
+++ b/olimage/filesystem/base.py
@@ -48,6 +48,11 @@ class FileSystemBase(object):
             if self._release_packages:
                 packages += self._release_packages.get_variant(str(self._variant_packages))
 
+            # Append extra packages from command line option
+            for pkg in env.options['extra_package']:
+                with Console(f'Extra package: {pkg}'):
+                    packages.append(pkg)
+
             # Try 5 times to install packages
             count = 5
             _e = None

--- a/olimage/filesystem/parameters.py
+++ b/olimage/filesystem/parameters.py
@@ -14,7 +14,10 @@ _options = [
     click.option("--keyboard-layout", default="English (UK)", help="Set default system keyboard locale"),
     click.option("--locale", default="en_GB.UTF-8", help="Set default system locale"),
     click.option("--ssh/--no-ssh", default=True, help="Enable/Disable ssh access"),
-    click.option("--timezone", default="Europe/London", help="Set default system timezone")
+    click.option("--timezone", default="Europe/London", help="Set default system timezone"),
+    click.option("--extra-file", multiple=True, default=[], help="Install an extra file from the overlay dir"),
+    click.option("--extra-cmd", multiple=True, default=[], help="Run an extra shell command after files installed"),
+    click.option("--extra-package", multiple=True, default=[], help="Add an extra package to be installed"),
 ]
 
 


### PR DESCRIPTION
When creating an image the `--extra-package` option can be used to
install an additional package into the filesystem.

Similarly the `--extra-file` option can be used to install
an additional file from `overlay/` into the filesystem.

Finally the `--extra-cmd` option can be used to run a command on the
filesystem.

All of these option can be specified multiple times.